### PR TITLE
[ Kibble ] Link and Unlink commands

### DIFF
--- a/packages/gh/composer.json
+++ b/packages/gh/composer.json
@@ -4,7 +4,7 @@
 	"type": "library",
 	"license": "MIT",
 	"require": {
-        "illuminate/support": "^11.36"
+        "illuminate/support": "^11.9"
     },
     "require-dev": {
         "larastan/larastan": "^v3.0.2",

--- a/packages/kibble/composer.json
+++ b/packages/kibble/composer.json
@@ -5,7 +5,7 @@
 	"license": "MIT",
 	"require": {
         "artisan-build/gh": "*",
-        "illuminate/support": "^11.36"
+        "illuminate/support": "^11.9"
     },
     "require-dev": {
         "larastan/larastan": "^v3.0.2",

--- a/packages/kibble/src/Actions/KibbleGitIgnore.php
+++ b/packages/kibble/src/Actions/KibbleGitIgnore.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ArtisanBuild\Kibble\Actions;
+
+use ArtisanBuild\Bench\Attributes\ChatGPT;
+
+class KibbleGitIgnore
+{
+    #[ChatGPT]
+    public function __invoke(): void
+    {
+        if (! shell_exec('git check-ignore kibble.json')) {
+            $gitignore = file_get_contents('.gitignore');
+            $lines = explode("\n", $gitignore);
+            $kibbleIndex = -1;
+
+            // Find appropriate spot to insert kibble.json alphabetically
+            for ($i = 0; $i < count($lines); $i++) {
+                if (trim($lines[$i]) === '') {
+                    continue;
+                }
+                if (strcasecmp('kibble.json', $lines[$i]) > 0) {
+                    continue;
+                }
+                $kibbleIndex = $i;
+                break;
+            }
+
+            if ($kibbleIndex === -1) {
+                $lines[] = 'kibble.json';
+            } else {
+                array_splice($lines, $kibbleIndex, 0, 'kibble.json');
+            }
+
+            file_put_contents('.gitignore', implode("\n", $lines));
+        }
+    }
+}

--- a/packages/kibble/src/Actions/KibbleGitIgnore.php
+++ b/packages/kibble/src/Actions/KibbleGitIgnore.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace ArtisanBuild\Kibble\Actions;
 
-use ArtisanBuild\Bench\Attributes\ChatGPT;
+// TODO: Don't want to add this dependency just for this one attribute.
+// use ArtisanBuild\Bench\Attributes\ChatGPT;
 
 class KibbleGitIgnore
 {
-    #[ChatGPT]
+    // #[ChatGPT]
     public function __invoke(): void
     {
         if (! shell_exec('git check-ignore kibble.json')) {

--- a/packages/kibble/src/Commands/LinkCommand.php
+++ b/packages/kibble/src/Commands/LinkCommand.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ArtisanBuild\Kibble\Commands;
+
+use ArtisanBuild\Kibble\Actions\KibbleGitIgnore;
+use Illuminate\Console\Command;
+
+class LinkCommand extends Command
+{
+    protected $signature = 'kibble:link {repository}';
+
+    protected $description = 'Add a Kibble monorepo to your composer project';
+
+    public function handle(): int
+    {
+        app(KibbleGitIgnore::class)();
+
+        if (! file_exists('kibble.json')) {
+            file_put_contents(
+                filename: 'kibble.json',
+                data: json_encode(
+                    value: [],
+                    flags: JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+                ).PHP_EOL
+            );
+        }
+
+        $kibble = json_decode(file_get_contents('kibble.json'), true);
+
+        $repository = $this->argument('repository');
+
+        if (! isset($kibble[$repository])) {
+            if (! $this->confirm(
+                question: "{$repository} repository not found in kibble.json. Would you like to add it?",
+                default: true,
+            )) {
+                return Command::FAILURE;
+            }
+
+            $path = $this->ask('Enter the path to the repository (without trailing slash)');
+
+            $path = str_ends_with((string) $path, '/*') ? $path : $path.'/*';
+
+            // "dogfood": {
+            //     "type": "path",
+            //     "url": "/Users/gopher/Code/artisan-build/dogfood/packages/*",
+            //     "options": {
+            //         "symlink": true
+            //     }
+            // },
+            $kibble[$repository] = [
+                'type' => 'path',
+                'url' => $path,
+                'options' => [
+                    'symlink' => true,
+                ],
+            ];
+
+            file_put_contents(
+                filename: 'kibble.json',
+                data: json_encode(
+                    value: $kibble,
+                    flags: JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+                ).PHP_EOL
+            );
+        }
+
+        /**
+         * Now start work on the composer.json file.
+         */
+
+        $composer_json = file_get_contents('composer.json');
+        $trailing_newline = str_ends_with($composer_json, "\n");
+
+        $composer = json_decode($composer_json, true);
+
+        if (! isset($composer['repositories'])) {
+            $composer['repositories'] = [];
+        }
+
+        if (
+            isset($composer['repositories'][$repository]) &&
+            $composer['repositories'][$repository] === $kibble[$repository]
+        ) {
+            $this->info("{$repository} already in composer.json");
+
+            return Command::SUCCESS;
+        }
+
+        if (
+            isset($composer['repositories'][$repository]) &&
+            $composer['repositories'][$repository] !== $kibble[$repository]
+        ) {
+            $this->error("{$repository} already in composer.json but with different configuration.");
+
+            return Command::FAILURE;
+        }
+
+        $composer['repositories'][$repository] = $kibble[$repository];
+
+        file_put_contents(
+            filename: 'composer.json',
+            data: json_encode(
+                value: $composer,
+                flags: JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+            ).($trailing_newline ? "\n" : '')
+        );
+
+        $this->info("{$repository} added to composer.json");
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/kibble/src/Commands/LinkCommand.php
+++ b/packages/kibble/src/Commands/LinkCommand.php
@@ -70,7 +70,6 @@ class LinkCommand extends Command
         /**
          * Now start work on the composer.json file.
          */
-
         $composer_json = file_get_contents('composer.json');
         $trailing_newline = str_ends_with($composer_json, "\n");
 

--- a/packages/kibble/src/Commands/UnlinkCommand.php
+++ b/packages/kibble/src/Commands/UnlinkCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ArtisanBuild\Kibble\Commands;
+
+use ArtisanBuild\Kibble\Actions\KibbleGitIgnore;
+use Illuminate\Console\Command;
+
+class UnlinkCommand extends Command
+{
+    protected $signature = 'kibble:unlink {repository}';
+
+    protected $description = 'Temporarily remove a Kibble monorepo from your composer project';
+
+    public function handle(): int
+    {
+        $repository = $this->argument('repository');
+
+        $composer_json = file_get_contents('composer.json');
+        $trailing_newline = str_ends_with($composer_json, "\n");
+
+        $composer = json_decode($composer_json, true);
+
+        if (! isset($composer['repositories'][$repository])) {
+            $this->error("{$repository} repository not found in composer.json");
+
+            return Command::FAILURE;
+        }
+
+        app(KibbleGitIgnore::class)();
+
+        file_put_contents(
+            filename: 'kibble.json',
+            data: json_encode(
+                value: [$repository => $composer['repositories'][$repository]],
+                flags: JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+            ).($trailing_newline ? "\n" : '')
+        );
+
+        unset($composer['repositories'][$repository]);
+
+        file_put_contents(
+            filename: 'composer.json',
+            data: json_encode(
+                value: $composer,
+                flags: JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+            ).($trailing_newline ? "\n" : '')
+        );
+
+        $this->info("{$repository} repository removed from composer.json");
+        $this->info('Run `composer update` to remove the repository from your project.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/kibble/src/Providers/KibbleServiceProvider.php
+++ b/packages/kibble/src/Providers/KibbleServiceProvider.php
@@ -4,7 +4,9 @@ namespace ArtisanBuild\Kibble\Providers;
 
 use ArtisanBuild\Kibble\Commands\CreatePackageCommand;
 use ArtisanBuild\Kibble\Commands\ImportPackageCommand;
+use ArtisanBuild\Kibble\Commands\LinkCommand;
 use ArtisanBuild\Kibble\Commands\SplitPackagesCommand;
+use ArtisanBuild\Kibble\Commands\UnlinkCommand;
 use Illuminate\Support\ServiceProvider;
 
 class KibbleServiceProvider extends ServiceProvider
@@ -21,7 +23,10 @@ class KibbleServiceProvider extends ServiceProvider
             CreatePackageCommand::class,
             ImportPackageCommand::class,
             SplitPackagesCommand::class,
+            LinkCommand::class,
+            UnlinkCommand::class,
         ]);
+
         $this->publishes([
             __DIR__.'/../../config/kibble.php' => config_path('kibble.php'),
         ], 'kibble');


### PR DESCRIPTION
Adds `LinkCommand` and `UnlinkCommand`.

Right now the input for repository path does not autosuggest anything. Might add `community-prompts` as a dep to use the `FileExplorerPrompt`.

Reduced Laravel dependency in Kibble and GH to 11.9 from 11.36 to make this installable in `artisan-build/community`