### PR TITLE
Add support for vimeo review urls

### DIFF
--- a/packages/embeddable-links/src/Services/UrlParser.php
+++ b/packages/embeddable-links/src/Services/UrlParser.php
@@ -78,6 +78,11 @@ readonly class UrlParser
 
     protected function extractVimeoId(string $url): ?string
     {
+        // Review: vimeo.com/reviews/{review_id}/videos/VIDEO_ID
+        if (preg_match('/vimeo\.com\/reviews\/[^\/]+\/videos\/(\d+)/', $url, $matches)) {
+            return $matches[1];
+        }
+
         // Standard: vimeo.com/VIDEO_ID
         if (preg_match('/vimeo\.com\/(\d+)/', $url, $matches)) {
             return $matches[1];

--- a/packages/embeddable-links/tests/Unit/UrlParserTest.php
+++ b/packages/embeddable-links/tests/Unit/UrlParserTest.php
@@ -44,6 +44,14 @@ test('detects Vimeo player URL', function (): void {
         ->id->toBe('123456789');
 });
 
+test('detects Vimeo review URL', function (): void {
+    $parser = new UrlParser;
+
+    expect($parser->parse('https://vimeo.com/reviews/2ac9fd34-2efb-439c-be44-828462a64c44/videos/1135525785'))
+        ->service->toBe('vimeo')
+        ->id->toBe('1135525785');
+});
+
 test('detects GitHub Gist URL', function (): void {
     $parser = new UrlParser;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds support for parsing Vimeo review links.
> 
> - Extend `UrlParser::extractVimeoId` to handle `vimeo.com/reviews/{review_id}/videos/{VIDEO_ID}` via new regex
> - Add unit test in `UrlParserTest.php` verifying service `vimeo` and correct ID extraction for review URLs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f59f335a43eefe2f0cef50453a8e4748b796377e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->