### PR TITLE
Fix EnumCollection generic type resolution in collect()

### DIFF
--- a/packages/fat-enums/src/Collections/CollectibleEnumMethods.php
+++ b/packages/fat-enums/src/Collections/CollectibleEnumMethods.php
@@ -6,6 +6,11 @@ namespace ArtisanBuild\FatEnums\Collections;
 
 trait CollectibleEnumMethods
 {
+    /**
+     * Collect all cases of this enum into a type-safe EnumCollection.
+     *
+     * @return EnumCollection<static>
+     */
     public static function collect(): EnumCollection
     {
         // We're going to use the enum class name to create the


### PR DESCRIPTION
## Summary

- Add `@return EnumCollection<static>` PHPDoc to `CollectibleEnumMethods::collect()` so PHPStan resolves the template parameter to the concrete enum class instead of the `UnitEnum` upper bound

Closes #79

## Test plan

- [x] PHPStan passes on the changed file
- [x] All CollectibleEnumMethods tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)