### PR TITLE
feat(bonfire): proper poll modal, sticky-bottom scroll, menu cleanup

### DIFF
--- a/packages/bonfire/resources/views/components/layouts/bonfire.blade.php
+++ b/packages/bonfire/resources/views/components/layouts/bonfire.blade.php
@@ -71,11 +71,6 @@
                                                     wire:navigate>
                                         Workspace settings
                                     </flux:menu.item>
-                                    <flux:menu.item icon="shield-check"
-                                                    href="{{ route('bonfire.admin.index') }}"
-                                                    wire:navigate>
-                                        Admin panel
-                                    </flux:menu.item>
                                 @else
                                     <flux:menu.item icon="cog-6-tooth" disabled>Workspace settings</flux:menu.item>
                                 @endif

--- a/packages/bonfire/resources/views/components/message-composer/message-composer.blade.php
+++ b/packages/bonfire/resources/views/components/message-composer/message-composer.blade.php
@@ -218,22 +218,6 @@
               this.showEmoji = false;
           },
 
-          insertPollTemplate() {
-              const template = '/poll What should we do? | Option 1 | Option 2 | Option 3';
-              const el = document.querySelector('.bonfire-composer [data-flux-editor]')
-                  ?? document.querySelector('[data-flux-editor]');
-              const editor = el?._tiptap || el?.editor;
-              if (editor) {
-                  editor.chain().focus()
-                      .clearContent()
-                      .insertContent(template)
-                      .run();
-              }
-              try {
-                  this.$wire.set('body', '<p>' + template + '</p>', false);
-              } catch (e) {}
-          },
-
           pollPreview() {
               const raw = (this.body || '').replace(/<[^>]+>/g, ' ')
                   .replace(/&nbsp;/g, ' ')
@@ -243,7 +227,7 @@
                   .replace(/&#39;/g, '\u0027')
                   .replace(/&quot;/g, '\u0022')
                   .trim();
-              const m = raw.match(/^\/poll\s+(.+)$/is);
+              const m = raw.match(/\/poll\s+(.+)$/is);
               if (! m) return null;
               const parts = m[1].split('|').map(s => s.trim()).filter(Boolean);
               if (parts.length < 3) return { question: parts[0] || '', options: parts.slice(1), valid: false };
@@ -606,7 +590,45 @@
             </div>
         </div>
 
-        <template x-if="pollPreview()">
+        @if ($pendingPoll !== null)
+            <div class="mb-1 block w-full rounded-md border border-sky-200 bg-sky-50 p-3
+                        dark:border-sky-800 dark:bg-sky-950/40">
+                <div class="flex items-center justify-between gap-3">
+                    <div class="flex min-w-0 items-center gap-2">
+                        <flux:icon name="chart-bar" class="size-4 shrink-0 text-sky-600 dark:text-sky-400" />
+                        <span class="text-[11px] font-semibold uppercase tracking-wider text-sky-700 dark:text-sky-300">
+                            {{ __('Poll attached') }}
+                        </span>
+                        <span class="text-[11px] text-sky-500/80 dark:text-sky-400/80">
+                            · {{ trans_choice('{1}1 option|[2,*]:count options', count($pendingPoll['options'] ?? [])) }}
+                        </span>
+                    </div>
+                    <div class="flex shrink-0 items-center gap-1">
+                        <button type="button"
+                                wire:click="editPendingPoll"
+                                title="{{ __('Edit poll') }}"
+                                class="rounded p-1 text-sky-700 hover:bg-sky-100
+                                       dark:text-sky-300 dark:hover:bg-sky-900/40">
+                            <flux:icon name="pencil-square" class="size-4" />
+                        </button>
+                        <button type="button"
+                                wire:click="discardPendingPoll"
+                                title="{{ __('Remove poll') }}"
+                                class="rounded p-1 text-sky-700 hover:bg-sky-100
+                                       dark:text-sky-300 dark:hover:bg-sky-900/40">
+                            <flux:icon name="x-mark" class="size-4" />
+                        </button>
+                    </div>
+                </div>
+                @if (! empty($pendingPoll['question']))
+                    <div class="mt-1 truncate text-sm text-zinc-900 dark:text-zinc-100">
+                        {{ $pendingPoll['question'] }}
+                    </div>
+                @endif
+            </div>
+        @endif
+
+        <template x-if="!@js((bool) $pendingPoll) && pollPreview()">
             <div class="mb-1 rounded-md border px-2.5 py-1.5 text-xs"
                  :class="pollPreview().valid
                     ? 'border-sky-200 bg-sky-50 text-sky-800 dark:border-sky-800 dark:bg-sky-950/40 dark:text-sky-200'
@@ -696,8 +718,9 @@
                     <flux:icon name="at-symbol" class="size-4" />
                 </button>
                 <button type="button"
-                        title="Create a poll (/poll Question? | Option 1 | Option 2)"
-                        @mousedown.prevent @click="insertPollTemplate()"
+                        title="Create a poll"
+                        @mousedown.prevent
+                        @click="$dispatch('modal-show', { name: 'create-poll' })"
                         class="rounded p-1.5 hover:bg-zinc-100 hover:text-zinc-900
                                dark:hover:bg-zinc-800 dark:hover:text-zinc-100">
                     <flux:icon name="chart-bar" class="size-4" />
@@ -936,4 +959,98 @@
             </template>
         </ul>
     </div>
+
+    {{-- Poll creation modal --}}
+    <flux:modal name="create-poll" class="md:w-[28rem]" @close="$wire.resetPollDraft()">
+        <form wire:submit.prevent="createPoll" class="space-y-6">
+            <div class="flex items-start gap-3">
+                <div class="flex size-9 flex-shrink-0 items-center justify-center rounded-lg bg-sky-100 text-sky-600
+                            dark:bg-sky-950/60 dark:text-sky-400">
+                    <flux:icon name="chart-bar" class="size-5" />
+                </div>
+                <div class="min-w-0 flex-1">
+                    <flux:heading size="lg">{{ __('Create a poll') }}</flux:heading>
+                    <flux:text class="mt-0.5 text-sm">
+                        {{ __('Anything you typed in the message box (including @mentions) will be sent above the poll.') }}
+                    </flux:text>
+                </div>
+            </div>
+
+            <flux:field>
+                <flux:label>{{ __('Question') }}</flux:label>
+                <flux:input wire:model="pollQuestion"
+                            maxlength="500"
+                            :placeholder="__('What should we do?')" />
+                <flux:error name="pollQuestion" />
+            </flux:field>
+
+            <flux:field>
+                <flux:label>{{ __('Options') }}</flux:label>
+
+                <div class="space-y-2">
+                    @foreach ($pollOptions as $index => $option)
+                        <div wire:key="poll-option-{{ $index }}"
+                             class="group flex items-center gap-2">
+                            <span class="flex size-7 flex-shrink-0 items-center justify-center rounded-md
+                                         border border-zinc-200 bg-zinc-50 text-xs font-semibold text-zinc-500 tabular-nums
+                                         dark:border-zinc-700 dark:bg-zinc-800/50 dark:text-zinc-400">
+                                {{ $index + 1 }}
+                            </span>
+
+                            <div class="min-w-0 flex-1">
+                                <flux:input wire:model="pollOptions.{{ $index }}"
+                                            maxlength="200"
+                                            :placeholder="__('Option :n', ['n' => $index + 1])" />
+                            </div>
+
+                            @if (count($pollOptions) > 2)
+                                <flux:button type="button"
+                                             variant="subtle"
+                                             size="sm"
+                                             icon="trash"
+                                             square
+                                             :title="__('Remove option')"
+                                             wire:click="removePollOption({{ $index }})"
+                                             class="opacity-0 transition group-hover:opacity-100 focus:opacity-100" />
+                            @else
+                                <span class="size-8 flex-shrink-0"></span>
+                            @endif
+                        </div>
+                    @endforeach
+                </div>
+
+                <flux:error name="pollOptions" />
+
+                @if (count($pollOptions) < 10)
+                    <div class="pt-1">
+                        <flux:button type="button"
+                                     variant="ghost"
+                                     size="sm"
+                                     icon="plus"
+                                     wire:click="addPollOption">
+                            {{ __('Add option') }}
+                        </flux:button>
+                    </div>
+                @endif
+            </flux:field>
+
+            <div class="flex flex-wrap items-center justify-between gap-3 border-t border-zinc-200 pt-4 dark:border-zinc-700">
+                <flux:text class="text-xs text-zinc-500">
+                    {{ trans_choice('{0}No options yet|{1}1 option|[2,*]:count options', count(array_filter($pollOptions, fn ($o) => trim((string) $o) !== ''))) }}
+                </flux:text>
+                <div class="flex flex-wrap gap-2">
+                    <flux:modal.close>
+                        <flux:button variant="ghost" type="button">{{ __('Cancel') }}</flux:button>
+                    </flux:modal.close>
+                    <flux:button type="button" variant="filled" icon="document-plus"
+                                 wire:click="stagePoll">
+                        {{ __('Add to message') }}
+                    </flux:button>
+                    <flux:button type="submit" variant="primary" icon="paper-airplane">
+                        {{ __('Send poll') }}
+                    </flux:button>
+                </div>
+            </div>
+        </form>
+    </flux:modal>
 </div>

--- a/packages/bonfire/resources/views/components/message-composer/message-composer.php
+++ b/packages/bonfire/resources/views/components/message-composer/message-composer.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use ArtisanBuild\Bonfire\Enums\BonfireRole;
 use ArtisanBuild\Bonfire\Facades\Bonfire;
 use ArtisanBuild\Bonfire\Models\Attachment;
 use ArtisanBuild\Bonfire\Models\Member;
@@ -32,6 +33,14 @@ return new class extends Component
 
     /** @var array<int, UploadedFile> */
     public array $pendingAttachments = [];
+
+    public string $pollQuestion = '';
+
+    /** @var array<int, string> */
+    public array $pollOptions = ['', ''];
+
+    /** @var array{question: string, options: array<int, string>}|null */
+    public ?array $pendingPoll = null;
 
     public function mount(Room $room, ?int $parentId = null): void
     {
@@ -88,18 +97,22 @@ return new class extends Component
         $body = trim($this->body);
         $plain = trim(strip_tags(html_entity_decode($body, ENT_QUOTES | ENT_HTML5)));
 
-        if ($plain === '' && $this->pendingAttachments === []) {
+        if ($plain === '' && $this->pendingAttachments === [] && $this->pendingPoll === null) {
             return;
         }
 
         $member = Bonfire::memberFor(auth()->user());
         abort_unless($member !== null && $member->is_active, 403);
+        $this->ensureMemberMayPost($member);
 
         $parent = $this->parentId !== null ? Message::query()->findOrFail($this->parentId) : null;
 
-        $poll = $this->parsePollCommand($plain);
+        // Staged poll wins over a typed /poll command.
+        $poll = $this->pendingPoll ?? $this->parsePollCommand($plain);
 
-        $effectiveBody = $plain === '' ? '📎' : $body;
+        $effectiveBody = $plain === ''
+            ? ($poll !== null ? (string) ($poll['question'] ?? '📎') : '📎')
+            : $body;
 
         $scheduledAt = $this->scheduledFor !== null && $this->scheduledFor !== ''
             ? Carbon::parse($this->scheduledFor)
@@ -109,7 +122,10 @@ return new class extends Component
             $scheduledAt = null;
         }
 
-        if ($poll !== null) {
+        // /poll slash-command: replace body with the bare question (the slash-command
+        // string itself is not useful as visible body). Staged poll: keep the user's
+        // typed body so @mentions and accompanying text survive.
+        if ($poll !== null && $this->pendingPoll === null) {
             $effectiveBody = $poll['question'];
         }
 
@@ -125,7 +141,9 @@ return new class extends Component
             $this->lastScheduledAt = $scheduledAt->toIso8601String();
         }
 
+        $this->pendingPoll = null;
         $this->reset('body', 'pendingAttachments', 'scheduledFor', 'alsoSendToChannel');
+        $this->dispatch('bonfire-own-message-sent');
     }
 
     /**
@@ -198,6 +216,136 @@ return new class extends Component
         }
 
         return Message::query()->create($attrs);
+    }
+
+    /**
+     * Reject if the room is announcement-only and the member is not at least a moderator.
+     */
+    private function ensureMemberMayPost(Member $member): void
+    {
+        if (! $this->room->isAnnouncements()) {
+            return;
+        }
+
+        abort_unless($member->hasRoleAtLeast(BonfireRole::Moderator), 403);
+    }
+
+    public function addPollOption(): void
+    {
+        if (count($this->pollOptions) < 10) {
+            $this->pollOptions[] = '';
+        }
+    }
+
+    public function removePollOption(int $index): void
+    {
+        if (count($this->pollOptions) <= 2) {
+            return;
+        }
+
+        unset($this->pollOptions[$index]);
+        $this->pollOptions = array_values($this->pollOptions);
+    }
+
+    public function resetPollDraft(): void
+    {
+        $this->pollQuestion = '';
+        $this->pollOptions = ['', ''];
+        $this->resetErrorBag(['pollQuestion', 'pollOptions']);
+    }
+
+    /**
+     * @return array{question: string, options: array<int, string>}|null
+     */
+    private function validatePollDraft(): ?array
+    {
+        $this->validate([
+            'pollQuestion' => ['required', 'string', 'min:1', 'max:500'],
+            'pollOptions' => ['array', 'min:2', 'max:10'],
+            'pollOptions.*' => ['nullable', 'string', 'max:200'],
+        ]);
+
+        $options = array_values(array_filter(
+            array_map(fn (string $o): string => trim($o), $this->pollOptions),
+            fn (string $o): bool => $o !== '',
+        ));
+
+        if (count($options) < 2) {
+            $this->addError('pollOptions', __('Add at least 2 non-empty options.'));
+
+            return null;
+        }
+
+        return [
+            'question' => trim($this->pollQuestion),
+            'options' => array_slice($options, 0, 10),
+        ];
+    }
+
+    public function createPoll(): void
+    {
+        $poll = $this->validatePollDraft();
+        if ($poll === null) {
+            return;
+        }
+
+        $member = Bonfire::memberFor(auth()->user());
+        abort_unless($member !== null && $member->is_active, 403);
+        $this->ensureMemberMayPost($member);
+
+        $parent = $this->parentId !== null ? Message::query()->findOrFail($this->parentId) : null;
+
+        $bodyHtml = trim($this->body);
+        $bodyPlain = trim(strip_tags(html_entity_decode($bodyHtml, ENT_QUOTES | ENT_HTML5)));
+        $effectiveBody = $bodyPlain === '' ? $poll['question'] : $bodyHtml;
+
+        $this->createMessage($member, $parent, $effectiveBody, null, $poll);
+
+        if ($parent !== null && $this->alsoSendToChannel) {
+            Bonfire::postAs($member, $this->room, $effectiveBody, null);
+        }
+
+        $this->reset('body');
+        $this->pendingPoll = null;
+        $this->resetPollDraft();
+        $this->dispatch('modal-close', name: 'create-poll');
+        $this->dispatch('bonfire-own-message-sent');
+    }
+
+    /**
+     * Stage the poll into the draft so the user can keep typing before sending.
+     */
+    public function stagePoll(): void
+    {
+        $poll = $this->validatePollDraft();
+        if ($poll === null) {
+            return;
+        }
+
+        $this->pendingPoll = $poll;
+        $this->resetPollDraft();
+        $this->dispatch('modal-close', name: 'create-poll');
+    }
+
+    /**
+     * Reopen the modal pre-filled with the staged poll for editing.
+     */
+    public function editPendingPoll(): void
+    {
+        if ($this->pendingPoll === null) {
+            return;
+        }
+
+        $this->pollQuestion = (string) ($this->pendingPoll['question'] ?? '');
+        $options = $this->pendingPoll['options'] ?? [];
+        $this->pollOptions = count($options) >= 2 ? array_values($options) : ['', ''];
+
+        $this->dispatch('modal-show', name: 'create-poll');
+    }
+
+    public function discardPendingPoll(): void
+    {
+        $this->pendingPoll = null;
     }
 
     private function storeAttachments(Message $message): void

--- a/packages/bonfire/resources/views/components/message-list/message-list.blade.php
+++ b/packages/bonfire/resources/views/components/message-list/message-list.blade.php
@@ -112,11 +112,57 @@
              }
              requestAnimationFrame(() => { this._highlighting = false; });
          },
+         nearBottom: true,
+         forceScrollNext: false,
+         updateNearBottom() {
+             const threshold = 100;
+             this.nearBottom = $el.scrollTop + $el.clientHeight >= $el.scrollHeight - threshold;
+         },
+         scrollToBottom(smooth = true) {
+             $el.scrollTo({ top: $el.scrollHeight, behavior: smooth ? 'smooth' : 'auto' });
+         },
          init() {
              $el.scrollTop = $el.scrollHeight;
              this.$nextTick(() => this.applyHighlight());
-             const obs = new MutationObserver(() => this.applyHighlight());
+
+             // Track whether the user is parked at the bottom so auto-scroll only kicks
+             // in when it won't yank them away from history they're reading.
+             this.updateNearBottom();
+             $el.addEventListener('scroll', () => this.updateNearBottom(), { passive: true });
+
+             const isMessageLi = (n) => n && n.nodeType === 1
+                 && n.tagName === 'LI'
+                 && typeof n.id === 'string'
+                 && n.id.indexOf('m-') === 0;
+             const containsMessageLi = (n) => {
+                 if (! n || n.nodeType !== 1 || typeof n.querySelectorAll !== 'function') return false;
+                 const lis = n.querySelectorAll('li');
+                 for (let i = 0; i < lis.length; i++) {
+                     if (isMessageLi(lis[i])) return true;
+                 }
+                 return false;
+             };
+
+             const obs = new MutationObserver((mutations) => {
+                 this.applyHighlight();
+
+                 const hasNewMessage = mutations.some(m =>
+                     m.type === 'childList' && Array.from(m.addedNodes).some(n =>
+                         isMessageLi(n) || containsMessageLi(n)
+                     )
+                 );
+
+                 if (hasNewMessage && (this.nearBottom || this.forceScrollNext)) {
+                     this.forceScrollNext = false;
+                     this.$nextTick(() => this.scrollToBottom());
+                 }
+             });
              obs.observe($el, { childList: true, subtree: true, characterData: true, attributes: true, attributeFilter: ['data-search'] });
+
+             // After we send our own message, force-scroll regardless of current position.
+             window.addEventListener('bonfire-own-message-sent', () => {
+                 this.forceScrollNext = true;
+             });
 
              // If the URL has a #m-123 hash when we arrive, jump to that message.
              this.$nextTick(() => this.focusHashMessage());
@@ -270,7 +316,19 @@
                                         $myOption = $currentMember
                                             ? (int) ($votes->firstWhere('member_id', $currentMember->id)?->option_index ?? -1)
                                             : -1;
+                                        $pollBodyPlain = trim(strip_tags(html_entity_decode((string) $message->body, ENT_QUOTES | ENT_HTML5)));
+                                        $questionPlain = trim((string) ($poll['question'] ?? ''));
+                                        $hasIntro = $pollBodyPlain !== '' && $pollBodyPlain !== $questionPlain;
                                     @endphp
+                                    @if ($hasIntro)
+                                        <div class="mb-2 max-w-none break-words">
+                                            @if ($bodyLooksLikeHtml)
+                                                {!! app(\ArtisanBuild\Bonfire\Support\MarkdownRenderer::class)->highlightMentions($message->body) !!}
+                                            @else
+                                                {!! app(\ArtisanBuild\Bonfire\Support\MarkdownRenderer::class)->render($message->body, $message->tenant_id) !!}
+                                            @endif
+                                        </div>
+                                    @endif
                                     <div class="mt-0.5 max-w-lg rounded-md border border-zinc-200 bg-white p-3
                                                 dark:border-zinc-700 dark:bg-zinc-900">
                                         <div class="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-sky-600 dark:text-sky-400">

--- a/packages/bonfire/resources/views/components/user-footer/user-footer.blade.php
+++ b/packages/bonfire/resources/views/components/user-footer/user-footer.blade.php
@@ -123,60 +123,49 @@
 
             <flux:menu.separator />
 
-            <div class="px-2 pb-1 pt-2 text-[11px] font-semibold uppercase tracking-wider text-zinc-500">
-                <span x-show="! dndActive">Pause notifications</span>
-                <span x-show="dndActive" x-text="dndLabel"></span>
+            <flux:menu.submenu icon="bell-slash" heading="Pause notifications">
+                <div class="px-2 pb-1 pt-1 text-[10px] font-semibold uppercase tracking-wider text-zinc-500"
+                     x-show="dndActive"
+                     x-text="dndLabel"></div>
+                <flux:menu.item icon="bell-slash" @click="pause(30)">For 30 minutes</flux:menu.item>
+                <flux:menu.item icon="bell-slash" @click="pause(60)">For 1 hour</flux:menu.item>
+                <flux:menu.item icon="bell-slash" @click="pause(240)">For 4 hours</flux:menu.item>
+                <flux:menu.item icon="moon" @click="pauseUntilTomorrow()">Until tomorrow</flux:menu.item>
+                <template x-if="dndUntil > now">
+                    <div>
+                        <flux:menu.separator />
+                        <flux:menu.item icon="arrow-uturn-left"
+                                        class="!text-sky-600 dark:!text-sky-400"
+                                        @click="pause(0)">
+                            Resume notifications
+                        </flux:menu.item>
+                    </div>
+                </template>
+            </flux:menu.submenu>
+
+            <div x-show="dndActive" class="px-2 pb-1 pt-1 text-[10px] text-sky-600 dark:text-sky-400">
+                <flux:icon name="moon" class="mr-1 inline size-3" />
+                <span x-text="dndLabel"></span>
             </div>
-            <button type="button" @click="pause(30)"
-                    class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm
-                           hover:bg-zinc-100 dark:text-zinc-100 dark:hover:bg-zinc-800">
-                <flux:icon name="bell-slash" class="size-4 text-zinc-500" />
-                <span>For 30 minutes</span>
-            </button>
-            <button type="button" @click="pause(60)"
-                    class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm
-                           hover:bg-zinc-100 dark:text-zinc-100 dark:hover:bg-zinc-800">
-                <flux:icon name="bell-slash" class="size-4 text-zinc-500" />
-                <span>For 1 hour</span>
-            </button>
-            <button type="button" @click="pause(240)"
-                    class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm
-                           hover:bg-zinc-100 dark:text-zinc-100 dark:hover:bg-zinc-800">
-                <flux:icon name="bell-slash" class="size-4 text-zinc-500" />
-                <span>For 4 hours</span>
-            </button>
-            <button type="button" @click="pauseUntilTomorrow()"
-                    class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm
-                           hover:bg-zinc-100 dark:text-zinc-100 dark:hover:bg-zinc-800">
-                <flux:icon name="moon" class="size-4 text-zinc-500" />
-                <span>Until tomorrow</span>
-            </button>
-            <button x-show="dndUntil > now" type="button" @click="pause(0)"
-                    class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm
-                           text-sky-600 hover:bg-zinc-100 dark:text-sky-400 dark:hover:bg-zinc-800">
-                <flux:icon name="arrow-uturn-left" class="size-4" />
-                <span>Resume notifications</span>
-            </button>
-
-            <flux:menu.separator />
-
-            <div x-show="quietEnabled" class="px-2 pb-1 pt-1 text-[10px] text-sky-600 dark:text-sky-400">
+            <div x-show="quietEnabled && ! dndUntil" class="px-2 pb-1 pt-1 text-[10px] text-sky-600 dark:text-sky-400">
                 <flux:icon name="moon" class="mr-1 inline size-3" />
                 <span x-text="'Quiet hours ' + quietFrom + '–' + quietTo + (inQuiet ? ' (active)' : '')"></span>
             </div>
 
             <flux:menu.separator />
-            <flux:menu.item icon="bell"
-                            href="{{ route('notifications.edit', absolute: false) }}" wire:navigate>
-                Notification settings
-            </flux:menu.item>
             <flux:menu.item icon="cog-6-tooth" href="{{ route('profile.edit', absolute: false) }}" wire:navigate>
-                Preferences
+                Settings
             </flux:menu.item>
+            @if (auth()->user()?->is_admin && \Illuminate\Support\Facades\Route::has('admin.features.index'))
+                <flux:menu.item icon="adjustments-horizontal"
+                                href="{{ route('admin.features.index', absolute: false) }}" wire:navigate>
+                    Feature flags
+                </flux:menu.item>
+            @endif
             <flux:menu.separator />
             <flux:menu.item icon="arrow-right-start-on-rectangle"
                             href="{{ route('logout', absolute: false) }}" wire:navigate>
-                Sign out of {{ config('app.name') }}
+                Sign out
             </flux:menu.item>
         </flux:menu>
     </flux:dropdown>


### PR DESCRIPTION
- Replace /poll slash-command UX with a Flux modal: question + 2-10 options, "Send poll" or "Add to message". The latter stages the poll in the composer with an inline edit/remove chip; sending the message attaches the poll without losing typed body or @mentions.
- createPoll() and stagePoll() persist directly via the existing createMessage path, no fragile string parsing.
- Poll messages render the typed body (with @mentions) above the poll widget so accompanying text and mentions actually show up.
- Sticky-bottom auto-scroll: MutationObserver watches new <li id="m-*">
  nodes; scrolls only when already near bottom (won't yank you out of history). Own sends always force-scroll via the new bonfire-own-message-sent browser event.
- Server-side announcement-room enforcement: ensureMemberMayPost() guard called from send() and createPoll() so the UI hide can't be bypassed via raw Livewire requests.
- User dropdown cleanup: collapsed Pause notifications into a hover submenu, removed redundant Notification settings entry, renamed Preferences → Settings, dropped the workspace-dropdown duplicate (Workspace settings + Admin panel pointed to the same route).
- Added admin-only Feature flags entry under Settings (gracefully hidden when host app doesn't register the route).