### PR TITLE
Add lockstep tagging to kibble:split

### DIFF
--- a/packages/kibble/README.md
+++ b/packages/kibble/README.md
@@ -15,6 +15,59 @@ This is the package that makes our package manager work.
 
 ## Usage
 
+### Splitting packages
+
+`php artisan kibble:split` mirrors each `packages/*` directory to its own read-only repository on
+GitHub. The monorepo is always the source of truth — split repositories are force-synced from it.
+
+```bash
+# Split every package (force-syncs each split repo's main branch)
+php artisan kibble:split
+
+# Split a single package
+php artisan kibble:split adverbs
+```
+
+### Lockstep release tagging
+
+Pass `--tag` to also tag every split repository with a release version, following the Laravel
+`illuminate/*` lockstep model — every split repo is tagged with the same version on every release,
+even packages with no changes:
+
+```bash
+# Force-sync main AND create the tag on every split repo
+php artisan kibble:split --tag=v1.2.0
+
+# Tag a single package
+php artisan kibble:split adverbs --tag=v1.2.0
+```
+
+Notes:
+
+- **Idempotent re-runs.** The tag is pushed with `--force`. `git subtree split` synthesizes new
+  commit SHAs on each run, so a re-run of a failed or partial release simply re-points the tag at
+  the new split commit rather than erroring that the tag already exists. (Re-publishing an
+  already-released version is still discouraged, but the mirror model permits it.)
+- **No local tag is created.** The tag is pushed via a ref-spec (`split-branch:refs/tags/<tag>`),
+  so no tag is written into the monorepo checkout. This avoids colliding with the monorepo's own
+  release tag that triggered the split in CI.
+- **Partial failures.** The command stops on the first failed sub-command, which can leave a
+  release partially tagged. Because tag pushes are force-idempotent, simply re-run the same command
+  to finish the release.
+- **CI requirements.** `git subtree split` needs full history, so check out with `fetch-depth: 0`.
+  Split repositories must already exist. Outside the local environment, pushes authenticate with the
+  `GH_USERNAME` / `GH_TOKEN` credentials (see Configuration).
+
+Example release workflow step (run on a monorepo tag push):
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0
+- run: composer install --no-interaction --prefer-dist
+- run: php artisan kibble:split --tag=${{ github.ref_name }}
+```
+
 ## Memberware
 
 This package is part of our internal toolkit and is optimized for our own purposes. We do not accept issues or PRs

--- a/packages/kibble/src/Commands/SplitPackagesCommand.php
+++ b/packages/kibble/src/Commands/SplitPackagesCommand.php
@@ -10,13 +10,27 @@ use Illuminate\Support\Facades\Process;
 
 class SplitPackagesCommand extends Command
 {
-    protected $signature = 'kibble:split {package? : The package name to split (e.g., adverbs, kibble). If omitted, all packages will be split.}';
+    protected $signature = 'kibble:split {package? : The package name to split (e.g., adverbs, kibble). If omitted, all packages will be split.}
+        {--tag= : Also tag each split repository with this version (e.g. v1.2.0). Enables lockstep releases.}';
 
     protected $description = 'Update all of the individual repositories for the packages';
 
     public function handle(): int
     {
         $packageFilter = $this->argument('package');
+
+        $tag = $this->option('tag');
+        if ($tag !== null) {
+            $tag = trim((string) $tag);
+
+            // Fail fast on an empty or obviously invalid ref before we touch any repo.
+            if ($tag === '' || str_starts_with($tag, '-') || preg_match('/\s/', $tag) === 1) {
+                $this->error("Invalid --tag value: '{$this->option('tag')}'. Provide a git ref such as v1.2.0.");
+
+                return self::FAILURE;
+            }
+        }
+
         $packagesProcessed = 0;
 
         foreach (File::directories(base_path('packages')) as $package) {
@@ -46,8 +60,18 @@ class SplitPackagesCommand extends Command
             $commands = [
                 ['git', 'subtree', 'split', '--prefix=packages/'.last(explode('/', (string) $package)), '-b', 'split-branch'],
                 ['git', 'push', $repoUrl, 'split-branch:main', '--force'],
-                ['git', 'branch', '-D', 'split-branch'],
             ];
+
+            if ($tag !== null) {
+                // Push the freshly-split commit straight to a tag ref on the split repo. Using a
+                // ref-spec push means no local tag is created in this checkout, so it can't collide
+                // with the monorepo's own release tag that triggered the split. --force makes a
+                // re-run of a failed/partial release idempotent (re-points the tag at the new
+                // subtree-split SHA instead of erroring "tag already exists").
+                $commands[] = ['git', 'push', $repoUrl, 'split-branch:refs/tags/'.$tag, '--force'];
+            }
+
+            $commands[] = ['git', 'branch', '-D', 'split-branch'];
 
             foreach ($commands as $command) {
                 // We want to rely on our local git credentials if running locally.

--- a/packages/kibble/tests/SplitPackagesCommandTest.php
+++ b/packages/kibble/tests/SplitPackagesCommandTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Process;
+
+beforeEach(fn () => Process::fake());
+
+describe('kibble:split lockstep tagging', function (): void {
+    it('pushes a tag ref to the split repo for the filtered package when --tag is set', function (): void {
+        $this->artisan('kibble:split', ['package' => 'packagist', '--tag' => 'v1.2.0'])
+            ->assertSuccessful();
+
+        Process::assertRan('git push https://github.com/artisan-build/packagist.git split-branch:main --force');
+        Process::assertRan('git push https://github.com/artisan-build/packagist.git split-branch:refs/tags/v1.2.0 --force');
+    });
+
+    it('does not push any tag ref when --tag is omitted', function (): void {
+        $this->artisan('kibble:split', ['package' => 'packagist'])
+            ->assertSuccessful();
+
+        Process::assertRan('git push https://github.com/artisan-build/packagist.git split-branch:main --force');
+        Process::assertNotRan(fn ($process) => str_contains((string) $process->command, 'refs/tags/'));
+    });
+
+    it('tags only the filtered package, not every package', function (): void {
+        $this->artisan('kibble:split', ['package' => 'packagist', '--tag' => 'v1.2.0'])
+            ->assertSuccessful();
+
+        Process::assertNotRan(fn ($process) => str_contains((string) $process->command, 'kibble.git split-branch:refs/tags/'));
+    });
+
+    it('injects GitHub credentials into the tag push outside the local environment', function (): void {
+        config(['kibble.github_username' => 'ci-bot', 'kibble.github_token' => 'secret-token']);
+        app()->detectEnvironment(fn () => 'production');
+
+        $this->artisan('kibble:split', ['package' => 'packagist', '--tag' => 'v1.2.0'])
+            ->assertSuccessful();
+
+        Process::assertRan(fn ($process) => str_contains((string) $process->command, 'refs/tags/v1.2.0')
+            && ($process->environment['GIT_USERNAME'] ?? null) === 'ci-bot'
+            && ($process->environment['GIT_PASSWORD'] ?? null) === 'secret-token');
+    });
+
+    it('does not inject credentials in the local environment', function (): void {
+        app()->detectEnvironment(fn () => 'local');
+
+        $this->artisan('kibble:split', ['package' => 'packagist', '--tag' => 'v1.2.0'])
+            ->assertSuccessful();
+
+        Process::assertRan(fn ($process) => str_contains((string) $process->command, 'refs/tags/v1.2.0')
+            && $process->environment === []);
+    });
+
+    it('rejects an empty --tag before running any process', function (): void {
+        $this->artisan('kibble:split', ['package' => 'packagist', '--tag' => '   '])
+            ->assertFailed();
+
+        Process::assertNothingRan();
+    });
+
+    it('rejects a --tag containing whitespace before running any process', function (): void {
+        $this->artisan('kibble:split', ['package' => 'packagist', '--tag' => 'v1 2 0'])
+            ->assertFailed();
+
+        Process::assertNothingRan();
+    });
+
+    it('rejects a --tag that looks like a flag before running any process', function (): void {
+        $this->artisan('kibble:split', ['package' => 'packagist', '--tag' => '--force'])
+            ->assertFailed();
+
+        Process::assertNothingRan();
+    });
+});


### PR DESCRIPTION
## Summary

Adds a `--tag` option to `kibble:split` so a release can tag **every** split repository with the same version on every release — even packages with no changes — following the Laravel `illuminate/*` lockstep model. This unblocks consuming monorepos (e.g. Hone) running a single CI command on a monorepo tag to mirror and version all `packages/*` splits.

This is deliverable #2 from the "make kibble release-ready" brief.

## Changes

- **`SplitPackagesCommand`**: new `{--tag=}` option. When set, pushes the freshly-split commit to `refs/tags/<tag>` on each split repo via a ref-spec push — no local tag is created (so it can't collide with the monorepo's own release tag that triggered CI), and `--force` makes re-runs of a failed/partial release idempotent. Composes with the positional package filter; omitting `--tag` is byte-for-byte unchanged. `--tag` is validated up front (rejects empty/whitespace-only, whitespace-containing, or flag-like values) and fails before touching any repo. The tag push rides the existing `Process::env` credential path.
- **Tests**: 8 Pest cases (`Process::fake()`) covering the tag-ref push, no-tag default, filter scoping, credential injection in/out of the local environment, and the three validation-failure paths.
- **README**: documents `--tag`, idempotency, the no-local-tag rationale, partial-failure behavior, the `fetch-depth: 0` CI requirement, and a release-workflow example.

## Testing

⚠️ I could not run the suite locally — this checkout has no `vendor/` and `composer install` requires the Flux Pro license. Please run `composer ready` (or `composer test -- --filter=SplitPackagesCommand`) before merging. Both changed files pass `php -l`.

## Follow-ups (separate release actions, not in this PR)

- Cut `artisan-build/packagist` `v1.0.0` (hard blocker for installing kibble at stable on L13) — once merged: `php artisan kibble:split packagist --tag=v1.0.0`.
- Cut `kibble` `v1.1.0`: `php artisan kibble:split kibble --tag=v1.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)