### PR TITLE
Strip dev-only wiring from kibble:split artifacts

### DIFF
--- a/packages/kibble/README.md
+++ b/packages/kibble/README.md
@@ -28,6 +28,31 @@ php artisan kibble:split
 php artisan kibble:split adverbs
 ```
 
+### Distribution cleaning (default)
+
+A split repository exists to be published, so by default `kibble:split` does **not** copy each
+package's `composer.json` verbatim. It produces a *distribution* `composer.json` for the split that
+strips dev-only wiring which is load-bearing inside the monorepo but wrong in the published package:
+
+1. The top-level `version` field is removed so Packagist derives the version from the git tag rather
+   than a hardcoded value (a stale `version` field breaks tag-derived/lockstep versioning).
+2. `repositories` entries whose `type` is `path` are removed — their `../sibling` urls do not exist
+   for consumers and otherwise print `The url supplied for the path (../<sibling>) repository does
+   not exist` on every `composer require`. Non-`path` repositories are preserved, and the
+   `repositories` key is dropped entirely when nothing remains.
+
+Anything else in `composer.json` is left untouched. The strip is applied to the **split artifact
+only** — the monorepo's own `packages/<pkg>/composer.json` on disk is never modified. Mechanically,
+the cleaned content is committed in a detached worktree *after* `git subtree split` and *before* the
+pushes, so both `main` and any `--tag` ref point at the cleaned commit.
+
+Pass `--no-clean` to opt out and publish each `composer.json` verbatim (raw passthrough):
+
+```bash
+# Publish composer.json exactly as it appears in the monorepo
+php artisan kibble:split adverbs --no-clean
+```
+
 ### Lockstep release tagging
 
 Pass `--tag` to also tag every split repository with a release version, following the Laravel

--- a/packages/kibble/src/Commands/SplitPackagesCommand.php
+++ b/packages/kibble/src/Commands/SplitPackagesCommand.php
@@ -11,7 +11,8 @@ use Illuminate\Support\Facades\Process;
 class SplitPackagesCommand extends Command
 {
     protected $signature = 'kibble:split {package? : The package name to split (e.g., adverbs, kibble). If omitted, all packages will be split.}
-        {--tag= : Also tag each split repository with this version (e.g. v1.2.0). Enables lockstep releases.}';
+        {--tag= : Also tag each split repository with this version (e.g. v1.2.0). Enables lockstep releases.}
+        {--no-clean : Publish each package'."'".'s composer.json verbatim instead of stripping dev-only wiring (top-level "version" and "path" repositories).}';
 
     protected $description = 'Update all of the individual repositories for the packages';
 
@@ -30,6 +31,8 @@ class SplitPackagesCommand extends Command
                 return self::FAILURE;
             }
         }
+
+        $clean = ! $this->option('no-clean');
 
         $packagesProcessed = 0;
 
@@ -55,37 +58,14 @@ class SplitPackagesCommand extends Command
             $this->info("Splitting package at '{$package}' into repository '{$json['name']}'");
 
             $repoUrl = "https://github.com/{$json['name']}.git";
+            $prefix = 'packages/'.last(explode('/', (string) $package));
 
-            // Define commands to execute
-            $commands = [
-                ['git', 'subtree', 'split', '--prefix=packages/'.last(explode('/', (string) $package)), '-b', 'split-branch'],
-                ['git', 'push', $repoUrl, 'split-branch:main', '--force'],
-            ];
+            $result = $clean
+                ? $this->splitAndClean($repoUrl, $prefix, (string) $json['name'], $tag)
+                : $this->splitRaw($repoUrl, $prefix, $tag);
 
-            if ($tag !== null) {
-                // Push the freshly-split commit straight to a tag ref on the split repo. Using a
-                // ref-spec push means no local tag is created in this checkout, so it can't collide
-                // with the monorepo's own release tag that triggered the split. --force makes a
-                // re-run of a failed/partial release idempotent (re-points the tag at the new
-                // subtree-split SHA instead of erroring "tag already exists").
-                $commands[] = ['git', 'push', $repoUrl, 'split-branch:refs/tags/'.$tag, '--force'];
-            }
-
-            $commands[] = ['git', 'branch', '-D', 'split-branch'];
-
-            foreach ($commands as $command) {
-                // We want to rely on our local git credentials if running locally.
-                $process = Process::env(app()->isLocal() ? [] : [
-                    'GIT_ASKPASS' => 'echo',
-                    'GIT_USERNAME' => config('kibble.github_username'),
-                    'GIT_PASSWORD' => config('kibble.github_token'),
-                ])->run(implode(' ', $command));
-
-                if (! $process->successful()) {
-                    $this->error($process->errorOutput());
-
-                    return self::FAILURE;
-                }
+            if ($result !== self::SUCCESS) {
+                return $result;
             }
 
             $this->info("Done updating '{$json['name']}'");
@@ -106,5 +86,198 @@ class SplitPackagesCommand extends Command
         $this->info("Successfully processed {$packagesProcessed} package(s)");
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Produce the distribution composer.json for a split artifact.
+     *
+     * Dev-only wiring used to make local `^1.x` resolution work inside the monorepo is
+     * load-bearing there but wrong in the published package, so it is stripped from the
+     * split (never from the monorepo source on disk):
+     *
+     *   1. The top-level `version` field is removed so Packagist derives the version from
+     *      the git tag instead of a hardcoded value.
+     *   2. `repositories` entries of type `path` are removed (their `../sibling` urls do not
+     *      exist for consumers). Non-path repositories are preserved, and the `repositories`
+     *      key is dropped entirely when nothing is left.
+     *
+     * @param  array<string, mixed>  $composer
+     * @return array<string, mixed>
+     */
+    public function cleanComposerJson(array $composer): array
+    {
+        unset($composer['version']);
+
+        if (isset($composer['repositories']) && is_array($composer['repositories'])) {
+            $repositories = array_values(array_filter(
+                $composer['repositories'],
+                fn ($repository): bool => ! (is_array($repository) && ($repository['type'] ?? null) === 'path'),
+            ));
+
+            if ($repositories === []) {
+                unset($composer['repositories']);
+            } else {
+                $composer['repositories'] = $repositories;
+            }
+        }
+
+        return $composer;
+    }
+
+    /**
+     * Force-sync the split repo (and optional tag) straight from the subtree-split branch,
+     * publishing each package's composer.json verbatim. Used by --no-clean.
+     */
+    private function splitRaw(string $repoUrl, string $prefix, ?string $tag): int
+    {
+        $commands = [
+            ['git', 'subtree', 'split', '--prefix='.$prefix, '-b', 'split-branch'],
+            ['git', 'push', $repoUrl, 'split-branch:main', '--force'],
+        ];
+
+        if ($tag !== null) {
+            $commands[] = ['git', 'push', $repoUrl, 'split-branch:refs/tags/'.$tag, '--force'];
+        }
+
+        $commands[] = ['git', 'branch', '-D', 'split-branch'];
+
+        return $this->runCommands($commands);
+    }
+
+    /**
+     * Materialize the split content in a detached worktree, rewrite its composer.json into the
+     * distribution form, commit, then push that cleaned commit to main and (optionally) the tag.
+     *
+     * The rewrite happens after `git subtree split` and before any push so that both the main
+     * branch and the tag ref point at the cleaned commit. Using a worktree keeps the monorepo
+     * working tree (and the package's own composer.json on disk) untouched.
+     */
+    private function splitAndClean(string $repoUrl, string $prefix, string $name, ?string $tag): int
+    {
+        $worktree = $this->worktreePath($name);
+
+        $setup = $this->runCommands([
+            ['git', 'subtree', 'split', '--prefix='.$prefix, '-b', 'split-branch'],
+            ['git', 'worktree', 'add', '--detach', $worktree, 'split-branch'],
+        ]);
+
+        if ($setup !== self::SUCCESS) {
+            $this->cleanupWorktree($worktree);
+
+            return self::FAILURE;
+        }
+
+        if (! $this->rewriteWorktreeComposer($worktree)) {
+            $this->cleanupWorktree($worktree);
+
+            return self::FAILURE;
+        }
+
+        $commit = $this->runCommands([
+            ['git', '-C', $worktree, 'add', 'composer.json'],
+            ['git', '-C', $worktree, 'commit', '--allow-empty', '-m', "'Prepare ".$name." for distribution'"],
+        ]);
+
+        if ($commit !== self::SUCCESS) {
+            $this->cleanupWorktree($worktree);
+
+            return self::FAILURE;
+        }
+
+        $pushes = [
+            ['git', '-C', $worktree, 'push', $repoUrl, 'HEAD:main', '--force'],
+        ];
+
+        if ($tag !== null) {
+            $pushes[] = ['git', '-C', $worktree, 'push', $repoUrl, 'HEAD:refs/tags/'.$tag, '--force'];
+        }
+
+        $pushed = $this->runCommands($pushes);
+
+        $this->cleanupWorktree($worktree);
+
+        return $pushed;
+    }
+
+    /**
+     * Rewrite the split worktree's composer.json into its distribution form. Reads, transforms
+     * via cleanComposerJson(), and writes pretty JSON with a trailing newline. Only the artifact
+     * in the worktree is touched; the monorepo source composer.json is never modified.
+     */
+    private function rewriteWorktreeComposer(string $worktree): bool
+    {
+        $path = $worktree.'/composer.json';
+
+        $composer = json_decode(File::get($path), true);
+
+        if (! is_array($composer)) {
+            $this->error("Could not parse composer.json for the split at '{$worktree}'");
+
+            return false;
+        }
+
+        $cleaned = $this->cleanComposerJson($composer);
+
+        File::put(
+            $path,
+            json_encode($cleaned, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE).PHP_EOL,
+        );
+
+        return true;
+    }
+
+    /**
+     * Run a list of git commands in order, applying the same credential strategy used for pushes.
+     * Stops and reports on the first failure.
+     *
+     * @param  array<int, array<int, string>>  $commands
+     */
+    private function runCommands(array $commands): int
+    {
+        foreach ($commands as $command) {
+            // We want to rely on our local git credentials if running locally.
+            $process = Process::path(base_path())->env($this->pushEnvironment())
+                ->run(implode(' ', $command));
+
+            if (! $process->successful()) {
+                $this->error($process->errorOutput());
+
+                return self::FAILURE;
+            }
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Credential environment for git operations: local checkouts use the ambient credential
+     * helper (empty env); elsewhere we inject the configured GitHub username/token.
+     *
+     * @return array<string, string|null>
+     */
+    private function pushEnvironment(): array
+    {
+        return app()->isLocal() ? [] : [
+            'GIT_ASKPASS' => 'echo',
+            'GIT_USERNAME' => config('kibble.github_username'),
+            'GIT_PASSWORD' => config('kibble.github_token'),
+        ];
+    }
+
+    /**
+     * Best-effort teardown of the temporary worktree and the split branch. Failures here are
+     * ignored so a cleanup attempt never masks the real result of the split.
+     */
+    private function cleanupWorktree(string $worktree): void
+    {
+        Process::path(base_path())->env($this->pushEnvironment())
+            ->run('git worktree remove --force '.$worktree);
+        Process::path(base_path())->env($this->pushEnvironment())
+            ->run('git branch -D split-branch');
+    }
+
+    private function worktreePath(string $name): string
+    {
+        return rtrim(sys_get_temp_dir(), '/').'/kibble-split-'.str_replace('/', '-', $name);
     }
 }

--- a/packages/kibble/tests/SplitPackagesCommandTest.php
+++ b/packages/kibble/tests/SplitPackagesCommandTest.php
@@ -2,13 +2,20 @@
 
 declare(strict_types=1);
 
+use ArtisanBuild\Kibble\Commands\SplitPackagesCommand;
 use Illuminate\Support\Facades\Process;
 
-beforeEach(fn () => Process::fake());
+/*
+ * The credential, validation and push-wiring tests below exercise the raw passthrough path
+ * (--no-clean). That path keeps the original flat command list (subtree split -> push
+ * split-branch:main -> optional tag push -> branch -D), so it stays fully assertable under a
+ * blanket Process::fake() without needing a real worktree on disk.
+ */
+describe('kibble:split lockstep tagging (raw passthrough)', function (): void {
+    beforeEach(fn () => Process::fake());
 
-describe('kibble:split lockstep tagging', function (): void {
     it('pushes a tag ref to the split repo for the filtered package when --tag is set', function (): void {
-        $this->artisan('kibble:split', ['package' => 'packagist', '--tag' => 'v1.2.0'])
+        $this->artisan('kibble:split', ['package' => 'packagist', '--tag' => 'v1.2.0', '--no-clean' => true])
             ->assertSuccessful();
 
         Process::assertRan('git push https://github.com/artisan-build/packagist.git split-branch:main --force');
@@ -16,7 +23,7 @@ describe('kibble:split lockstep tagging', function (): void {
     });
 
     it('does not push any tag ref when --tag is omitted', function (): void {
-        $this->artisan('kibble:split', ['package' => 'packagist'])
+        $this->artisan('kibble:split', ['package' => 'packagist', '--no-clean' => true])
             ->assertSuccessful();
 
         Process::assertRan('git push https://github.com/artisan-build/packagist.git split-branch:main --force');
@@ -24,7 +31,7 @@ describe('kibble:split lockstep tagging', function (): void {
     });
 
     it('tags only the filtered package, not every package', function (): void {
-        $this->artisan('kibble:split', ['package' => 'packagist', '--tag' => 'v1.2.0'])
+        $this->artisan('kibble:split', ['package' => 'packagist', '--tag' => 'v1.2.0', '--no-clean' => true])
             ->assertSuccessful();
 
         Process::assertNotRan(fn ($process) => str_contains((string) $process->command, 'kibble.git split-branch:refs/tags/'));
@@ -34,7 +41,7 @@ describe('kibble:split lockstep tagging', function (): void {
         config(['kibble.github_username' => 'ci-bot', 'kibble.github_token' => 'secret-token']);
         app()->detectEnvironment(fn () => 'production');
 
-        $this->artisan('kibble:split', ['package' => 'packagist', '--tag' => 'v1.2.0'])
+        $this->artisan('kibble:split', ['package' => 'packagist', '--tag' => 'v1.2.0', '--no-clean' => true])
             ->assertSuccessful();
 
         Process::assertRan(fn ($process) => str_contains((string) $process->command, 'refs/tags/v1.2.0')
@@ -45,12 +52,25 @@ describe('kibble:split lockstep tagging', function (): void {
     it('does not inject credentials in the local environment', function (): void {
         app()->detectEnvironment(fn () => 'local');
 
-        $this->artisan('kibble:split', ['package' => 'packagist', '--tag' => 'v1.2.0'])
+        $this->artisan('kibble:split', ['package' => 'packagist', '--tag' => 'v1.2.0', '--no-clean' => true])
             ->assertSuccessful();
 
         Process::assertRan(fn ($process) => str_contains((string) $process->command, 'refs/tags/v1.2.0')
             && $process->environment === []);
     });
+
+    it('passes composer.json through untouched with --no-clean (no worktree rewrite)', function (): void {
+        $this->artisan('kibble:split', ['package' => 'packagist', '--no-clean' => true])
+            ->assertSuccessful();
+
+        // The raw path never materializes a worktree to rewrite composer.json in.
+        Process::assertNotRan(fn ($process) => str_contains((string) $process->command, 'worktree add'));
+        Process::assertRan('git push https://github.com/artisan-build/packagist.git split-branch:main --force');
+    });
+});
+
+describe('kibble:split tag validation', function (): void {
+    beforeEach(fn () => Process::fake());
 
     it('rejects an empty --tag before running any process', function (): void {
         $this->artisan('kibble:split', ['package' => 'packagist', '--tag' => '   '])
@@ -73,3 +93,148 @@ describe('kibble:split lockstep tagging', function (): void {
         Process::assertNothingRan();
     });
 });
+
+describe('cleanComposerJson distribution transform', function (): void {
+    it('drops the top-level version field', function (): void {
+        $cleaned = (new SplitPackagesCommand)->cleanComposerJson([
+            'name' => 'artisan-build/example',
+            'version' => '1.0.0',
+        ]);
+
+        expect($cleaned)->not->toHaveKey('version')
+            ->and($cleaned['name'])->toBe('artisan-build/example');
+    });
+
+    it('drops path repositories and removes the empty repositories key', function (): void {
+        $cleaned = (new SplitPackagesCommand)->cleanComposerJson([
+            'name' => 'artisan-build/example',
+            'repositories' => [
+                ['type' => 'path', 'url' => '../sibling'],
+            ],
+        ]);
+
+        expect($cleaned)->not->toHaveKey('repositories');
+    });
+
+    it('preserves a non-path repository while dropping path repositories', function (): void {
+        $cleaned = (new SplitPackagesCommand)->cleanComposerJson([
+            'name' => 'artisan-build/example',
+            'repositories' => [
+                ['type' => 'path', 'url' => '../sibling'],
+                ['type' => 'vcs', 'url' => 'https://github.com/artisan-build/other.git'],
+            ],
+        ]);
+
+        expect($cleaned['repositories'])->toBe([
+            ['type' => 'vcs', 'url' => 'https://github.com/artisan-build/other.git'],
+        ]);
+    });
+
+    it('leaves a composer with no version or path repositories unchanged', function (): void {
+        $composer = [
+            'name' => 'artisan-build/example',
+            'require' => ['php' => '^8.4'],
+        ];
+
+        expect((new SplitPackagesCommand)->cleanComposerJson($composer))->toBe($composer);
+    });
+});
+
+/*
+ * Integration coverage for the default (cleaning) path. We build a throwaway git monorepo
+ * containing a fixture package whose composer.json carries the dev-only wiring (a top-level
+ * "version" and a path repository), point the command's base_path() at it, and fake ONLY the
+ * network pushes so subtree-split, worktree add, the composer rewrite and the commit all run
+ * for real on disk. That lets us assert the artifact is cleaned, the tag points at the cleaned
+ * commit, and the monorepo source is never touched.
+ */
+describe('kibble:split cleaning (default) integration', function (): void {
+    beforeEach(function (): void {
+        $this->repo = sys_get_temp_dir().'/kibble-clean-test-'.uniqid();
+        $this->packageDir = $this->repo.'/packages/example';
+        @mkdir($this->packageDir.'/src', 0777, true);
+
+        $this->sourceComposer = [
+            'name' => 'artisan-build/example',
+            'version' => '1.0.0',
+            'repositories' => [
+                ['type' => 'path', 'url' => '../sibling', 'options' => ['symlink' => true]],
+                ['type' => 'vcs', 'url' => 'https://github.com/artisan-build/keepme.git'],
+            ],
+            'require' => ['php' => '^8.4'],
+        ];
+
+        file_put_contents(
+            $this->packageDir.'/composer.json',
+            json_encode($this->sourceComposer, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES).PHP_EOL,
+        );
+        file_put_contents($this->packageDir.'/src/Example.php', "<?php\n");
+
+        $git = fn (string $args) => Process::path($this->repo)->run('git '.$args);
+        $git('init -q');
+        $git('config user.email test@example.com');
+        $git('config user.name Test');
+        $git('config commit.gpgsign false');
+        $git('add -A');
+        $git('commit -q -m initial');
+
+        // Point the command at our throwaway monorepo and run locally (no injected creds).
+        app()->detectEnvironment(fn () => 'local');
+        app()->setBasePath($this->repo);
+    });
+
+    afterEach(function (): void {
+        Process::run('git worktree prune');
+        if (is_dir($this->repo)) {
+            Process::run('rm -rf '.escapeshellarg($this->repo));
+        }
+    });
+
+    it('publishes a cleaned artifact whose tag points at the stripped composer.json', function (): void {
+        $pushed = [];
+        $artifactComposer = null;
+        // Cleaned pushes run as `git -C <worktree> push ...`, so match on the push verb anywhere.
+        Process::fake([
+            '* push *' => function ($process) use (&$pushed, &$artifactComposer) {
+                $pushed[] = (string) $process->command;
+
+                // The worktree still exists at push time (cleanup runs after pushes), so we can
+                // read the exact composer.json that the pushed HEAD commit carries.
+                $path = cleanWorktreePath().'/composer.json';
+                if ($artifactComposer === null && is_file($path)) {
+                    $artifactComposer = file_get_contents($path);
+                }
+
+                return Process::result('');
+            },
+        ]);
+
+        $this->artisan('kibble:split', ['package' => 'example', '--tag' => 'v1.2.0'])
+            ->assertSuccessful();
+
+        // The monorepo source composer.json on disk is unchanged (artifact-only strip).
+        $source = json_decode(file_get_contents($this->packageDir.'/composer.json'), true);
+        expect($source)->toBe($this->sourceComposer);
+
+        // Both main and the tag ref were pushed from the cleaned worktree HEAD.
+        expect($pushed)->toContain('git -C '.cleanWorktreePath().' push https://github.com/artisan-build/example.git HEAD:main --force');
+        expect($pushed)->toContain('git -C '.cleanWorktreePath().' push https://github.com/artisan-build/example.git HEAD:refs/tags/v1.2.0 --force');
+
+        // The pushed (tagged) HEAD commit carries the cleaned composer.json: no version, no path
+        // repository, the non-path repository preserved, and a trailing newline on pretty JSON.
+        expect($artifactComposer)->not->toBeNull()
+            ->and($artifactComposer)->toEndWith("}\n");
+
+        $cleaned = json_decode((string) $artifactComposer, true);
+        expect($cleaned)->not->toHaveKey('version')
+            ->and($cleaned['repositories'])->toBe([
+                ['type' => 'vcs', 'url' => 'https://github.com/artisan-build/keepme.git'],
+            ])
+            ->and($cleaned['require'])->toBe(['php' => '^8.4']);
+    });
+});
+
+function cleanWorktreePath(): string
+{
+    return rtrim(sys_get_temp_dir(), '/').'/kibble-split-artisan-build-example';
+}


### PR DESCRIPTION
## What

`kibble:split` copied each package's `composer.json` verbatim, leaking **dev-only wiring** into the published split artifact:

- a hardcoded top-level `"version"` field, and
- `"repositories"` entries of `"type": "path"` (`../sibling` urls).

Both are load-bearing for local `^1.x` resolution **inside** a consuming monorepo (e.g. Hone's per-package CI) but **wrong in the distributed package**: the `version` field breaks tag-derived/lockstep versioning at the next release, and the path repo prints `The url supplied for the path (../<sibling>) repository does not exist` on every consumer `composer require`. (This dogfood repo's own packages have neither, so the feature is a no-op for them — but it must exist for consumers using that bootstrap pattern.)

## Change

By **default**, the split now publishes a *cleaned distribution* `composer.json`:

1. Remove the top-level `version` field (let Packagist derive version from the git tag).
2. Remove `repositories` entries whose `type` is `path`; preserve any non-path repository; drop the `repositories` key entirely if it becomes empty.
3. Otherwise leave `composer.json` unchanged.

A `--no-clean` flag opts out (raw passthrough).

**Artifact-only:** the monorepo's own `packages/<pkg>/composer.json` on disk is never modified. The rewrite happens in a detached `git worktree` *after* `git subtree split` and *before* the pushes, so both `main` and any `--tag` ref point at the **cleaned** commit.

## Tests

- `cleanComposerJson(array): array` pure transform — drops `version`, drops path repos, preserves non-path repos, removes empty `repositories` key, leaves clean composer untouched.
- Integration: a throwaway monorepo with a fixture package carrying the dev wiring; only network pushes are faked, so `subtree split` + worktree rewrite + commit run for real. Asserts the artifact is cleaned, the `--tag` ref points at the cleaned commit (trailing newline pretty JSON), and the source `composer.json` is unchanged.
- Existing `--tag` / no-tag / credential / validation behavior preserved (raw path now exercised via `--no-clean`).

## Gate

`pint` pass · `phpstan` no errors · `pest` (kibble suite) 14 passing, 35 assertions. Full root suite shows no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)